### PR TITLE
Added Some Saudi Arabia PII Dorks

### DIFF
--- a/Saudi Arabia/Citizens.md
+++ b/Saudi Arabia/Citizens.md
@@ -1,0 +1,5 @@
+### CVs/Resumes
+```
+intext:"+966" intext:@gmail.com intext:Saudi filetype:pdf OR filetype:xlsx
+intext:"+966" intext:@gmail.com inurl:sa filetype:pdf
+```

--- a/Saudi Arabia/Educational.md
+++ b/Saudi Arabia/Educational.md
@@ -1,9 +1,9 @@
 ### Students
 
 ```
-inurl:*.edu.sa intext:@gmail.com AND intext:@yahoo.com intext:nationality filetype:pdf OR filetype:xlsx
+inurl:edu.sa intext:@gmail.com AND intext:@yahoo.com intext:nationality filetype:pdf OR filetype:xlsx
 ```
 
 ```
-intext:"+966" intext:@gmail.com inurl:*.sa filetype:pdf OR filetype:xlsx
+intext:"+966" intext:@gmail.com inurl:sa filetype:pdf OR filetype:xlsx
 ```

--- a/Saudi Arabia/Government.md
+++ b/Saudi Arabia/Government.md
@@ -1,0 +1,17 @@
+### Iqama/National ID
+```
+site:*.gov.in intext:aadhaar AND intext:gender AND intext:name intitle:list filetype:pdf OR filetype:xlsx
+intext:@gmail.com intext:"Passport No." intext:"Kingdom of Saudi Arabia" filetype:pdf 100000..999999
+intext:@gmail.com intext:"Iqama Number" filetype:pdf 1000000000..3000000000
+intext:@gmail.com intext:"National ID" filetype:pdf 1000000000..3000000000
+
+```
+
+### Driver License
+```
+intext:"رخصة سياقة" intext:"DOB" filetype:pdf
+```
+
+### Building Permit
+```
+intext:"يجب الالتزام بتنفيذ العزل الحراري"


### PR DESCRIPTION
Interestingly enough there is only a limited amount of PII documents leaked on the internet. This is likely because Saudi Arabia is a bit behind when it comes to digitalizing documents (things on a whole except Government branches use old school pen/paper).

The Saudi Dorks involved in this pull include:
- CVs/Resumes
- Saudi National ID
- Iqama (Temporary Resident Permit)
- Driver License
- Building Permits
- Updates on the syntax in the Educational.md file (`inurl:*.sa `is no longer valid syntax when Googling. `inurl:sa` is now the wildcard equivalent)

Also better late than never (sorry for the delay).